### PR TITLE
Misc improvements 02

### DIFF
--- a/crawler-node/deploy.sh
+++ b/crawler-node/deploy.sh
@@ -8,7 +8,7 @@ ssh $1 "sudo mkdir -p ${TARGET_ROOT}; sudo chown -R ubuntu ${TARGET_ROOT}"
 
 rsync -L --delete --recursive --exclude 'var' \
       --exclude '.venv' --exclude '.git' \
-      src webindex-crawler-node.env local.env manage.sh Dockerfile .dockerignore docker-compose.yml src \
+      src webindex-crawler-node.env manage.sh Dockerfile .dockerignore docker-compose.yml src \
       $1:${TARGET_ROOT}
 
 echo "Finished deploy to $1"

--- a/crawler-node/src/crawler/website_exclusions.py
+++ b/crawler-node/src/crawler/website_exclusions.py
@@ -1,0 +1,20 @@
+"""
+Website-specific list of exclusions links
+Format: dict with key = domain regexp, value = list of regexps of blacklisted links.
+example:
+{
+    'humanservices.gov.au': [
+        '/admin/.*',  # all starting from /admin/
+        '*\.pdf$',  # anything ending with `.pdf`
+    ],
+    '.*': [ # any domain name
+        'tel:.*'
+    ]
+}
+"""
+
+EXCLUDE = {
+    '.*': [
+        'tel:.*',
+    ],
+}

--- a/crawler-node/src/tests_govcms.py
+++ b/crawler-node/src/tests_govcms.py
@@ -5,12 +5,14 @@ govCMS SaaS. We should replace this with a govCMS detector.
 import unittest
 from govcms import looks_like_govCMS_html
 
+
 class GovCMSTestCase(unittest.TestCase):
 
     def test_govcms_detector(self):
         with open("govcms/sample.html", 'r') as fp:
             score = looks_like_govCMS_html(fp)
         self.assertEqual(score, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Please note this PR includes previous to avoid merge problems in the future.

`website_exclusions.py` is not used yet, just start to document it.

www-no-www work has been changed, now we consider www and non-www domains different and:
* crawl only www domain if both www and non-www return some content (in hope that these websites will be actual anyway)
* crawl only final domain when one version redirects to another
* still respect https first

change steward behaviour, because it works bad with govcms domains - sends them to queue again and again, without awarenes of them sharing the same lock (no 2 govcms domains will be crawled at the same time).